### PR TITLE
feat: lazy load modals, fix loading UX, improve spinners

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,18 +1,21 @@
-import { useState, useCallback } from 'react';
+import { lazy, Suspense, useState, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
 import { useAppInitialization } from '@/hooks';
 import { useUpdateToast } from '@/hooks/useUpdateToast';
 import { useValidationSocket } from '@/hooks/useValidation';
 import { useReviewSocket } from '@/hooks/useReview';
 import { useRepositoryStore } from '@/stores/useRepositoryStore';
 import { useConnectionStore } from '@/stores/useConnectionStore';
+import { useSettingsStore } from '@/stores';
 import { useIssueStore } from '@/stores/useIssueStore';
 import { useReviewStore } from '@/stores/useReviewStore';
 import { TopBar, WelcomeView, TabBar } from '@/components/shared';
 import type { AppTab } from '@/components/shared';
-import { SettingsModal } from '@/components/settings';
 import { DashboardView } from '@/components/dashboard';
 import { IssueListView } from '@/components/issues';
 import { PRListView } from '@/components/pullrequests';
+
+const SettingsModal = lazy(() => import('@/components/settings/SettingsModal'));
 
 function App() {
   useAppInitialization();
@@ -23,6 +26,7 @@ function App() {
 
   const repositoryPath = useRepositoryStore(state => state.repositoryPath);
   const connectionStatus = useConnectionStore(state => state.status);
+  const settingsOpen = useSettingsStore(state => state.isOpen);
   const isConnected = repositoryPath !== null;
 
   const [activeTab, setActiveTab] = useState<AppTab>('dashboard');
@@ -58,7 +62,17 @@ function App() {
           <PRListView />
         )}
       </div>
-      <SettingsModal />
+      {settingsOpen && (
+        <Suspense
+          fallback={
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-xs">
+              <Loader2 size={24} className="animate-spin text-muted-foreground" />
+            </div>
+          }
+        >
+          <SettingsModal />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/issues/IssueListView.tsx
+++ b/apps/web/src/components/issues/IssueListView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { RefreshCw } from 'lucide-react';
+import { Loader2, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -48,6 +48,7 @@ function IssueCardSkeleton() {
 export function IssueListView({ className }: IssueListViewProps) {
   const { isLoading, error, refetch } = useIssues();
   const issues = useIssueStore(state => state.issues);
+  const hasFetched = useIssueStore(state => state.hasFetched);
   const sortBy = useIssueStore(state => state.sortBy);
   const filterLabels = useIssueStore(state => state.filterLabels);
   const selectedIssueNumber = useIssueStore(state => state.selectedIssueNumber);
@@ -112,7 +113,7 @@ export function IssueListView({ className }: IssueListViewProps) {
             disabled={isLoading}
             title="Refresh issues"
           >
-            <RefreshCw size={16} className={cn(isLoading && 'animate-spin')} />
+            {isLoading ? <Loader2 size={16} className="animate-spin" /> : <RefreshCw size={16} />}
           </Button>
         </div>
 
@@ -140,7 +141,7 @@ export function IssueListView({ className }: IssueListViewProps) {
 
         {/* Content */}
         <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 pb-4">
-          {isLoading && totalIssues === 0 ? (
+          {(!hasFetched || isLoading) && totalIssues === 0 ? (
             /* Loading skeletons */
             <div className="space-y-2">
               <IssueCardSkeleton />

--- a/apps/web/src/components/pullrequests/PRListView.tsx
+++ b/apps/web/src/components/pullrequests/PRListView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { RefreshCw } from 'lucide-react';
+import { Loader2, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -52,6 +52,7 @@ function PRCardSkeleton() {
 export function PRListView({ className }: PRListViewProps) {
   const { loading, error, refresh } = usePullRequests();
   const pullRequests = useReviewStore(state => state.pullRequests);
+  const hasFetched = useReviewStore(state => state.hasFetched);
   const sortBy = useReviewStore(state => state.sortBy);
   const selectedPrNumber = useReviewStore(state => state.selectedPrNumber);
   const setSelectedPr = useReviewStore(state => state.setSelectedPr);
@@ -129,7 +130,7 @@ export function PRListView({ className }: PRListViewProps) {
           disabled={loading}
           title="Refresh pull requests"
         >
-          <RefreshCw size={16} className={cn(loading && 'animate-spin')} />
+          {loading ? <Loader2 size={16} className="animate-spin" /> : <RefreshCw size={16} />}
         </Button>
       </div>
 
@@ -155,7 +156,7 @@ export function PRListView({ className }: PRListViewProps) {
 
       {/* Content */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 pb-4">
-        {loading && totalPRs === 0 ? (
+        {(!hasFetched || loading) && totalPRs === 0 ? (
           /* Loading skeletons */
           <div className="space-y-2">
             <PRCardSkeleton />

--- a/apps/web/src/components/settings/SettingsModal.tsx
+++ b/apps/web/src/components/settings/SettingsModal.tsx
@@ -12,7 +12,7 @@ import {
   ReviewPreferencesSection,
 } from './sections';
 
-export function SettingsModal() {
+export default function SettingsModal() {
   const isOpen = useSettingsStore(state => state.isOpen);
   const activeSection = useSettingsStore(state => state.activeSection);
   const closeSettings = useSettingsStore(state => state.closeSettings);

--- a/apps/web/src/components/settings/index.ts
+++ b/apps/web/src/components/settings/index.ts
@@ -1,3 +1,3 @@
-export { SettingsModal } from './SettingsModal';
+export { default as SettingsModal } from './SettingsModal';
 export { SettingsNavigation } from './SettingsNavigation';
 // Note: sections are not exported to avoid naming conflicts (e.g., McpSection exists in sidebar)

--- a/apps/web/src/components/validation/GithubPushPreview.tsx
+++ b/apps/web/src/components/validation/GithubPushPreview.tsx
@@ -237,7 +237,7 @@ function SectionRow({
  * Features Edit/Preview tabs with per-section checkboxes and textareas.
  * Supports detecting prior GitChorus comments for update-or-post-new.
  */
-export function GithubPushPreview({
+export default function GithubPushPreview({
   open,
   onOpenChange,
   issueNumber,

--- a/apps/web/src/components/validation/ValidationPanel.tsx
+++ b/apps/web/src/components/validation/ValidationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { lazy, Suspense, useState, useEffect } from 'react';
 import {
   Play,
   X,
@@ -20,8 +20,9 @@ import { useValidationStore } from '@/stores/useValidationStore';
 import { useValidation } from '@/hooks/useValidation';
 import { ValidationStepLog } from './ValidationStepLog';
 import { ValidationResults } from './ValidationResults';
-import { GithubPushPreview } from './GithubPushPreview';
 import type { ValidationStatus } from '@gitchorus/shared';
+
+const GithubPushPreview = lazy(() => import('./GithubPushPreview'));
 
 /**
  * Side panel that shows validation state for the selected issue.
@@ -289,17 +290,25 @@ export function ValidationPanel() {
           </>
         )}
 
-        {/* Push modal (Dialog portals itself) */}
-        {hasResult && result && (
-          <GithubPushPreview
-            open={showPushModal}
-            onOpenChange={setShowPushModal}
-            issueNumber={selectedIssueNumber}
-            result={result}
-            onPush={pushToGithub}
-            onUpdate={updateGithubComment}
-            onListComments={listComments}
-          />
+        {/* Push modal (lazy loaded, only mounted when open) */}
+        {showPushModal && hasResult && result && (
+          <Suspense
+            fallback={
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-xs">
+                <Loader2 size={24} className="animate-spin text-muted-foreground" />
+              </div>
+            }
+          >
+            <GithubPushPreview
+              open={showPushModal}
+              onOpenChange={setShowPushModal}
+              issueNumber={selectedIssueNumber}
+              result={result}
+              onPush={pushToGithub}
+              onUpdate={updateGithubComment}
+              onListComments={listComments}
+            />
+          </Suspense>
         )}
 
         {/* Error state */}

--- a/apps/web/src/components/validation/index.ts
+++ b/apps/web/src/components/validation/index.ts
@@ -1,5 +1,5 @@
 export { ValidationPanel } from './ValidationPanel';
 export { ValidationStepLog } from './ValidationStepLog';
 export { ValidationResults } from './ValidationResults';
-export { GithubPushPreview } from './GithubPushPreview';
+export { default as GithubPushPreview } from './GithubPushPreview';
 export { ValidationHistory } from './ValidationHistory';


### PR DESCRIPTION
## Summary
- **Lazy load SettingsModal** — only mounted when settings are open, reducing initial bundle size
- **Lazy load GithubPushPreview** — only mounted when push modal is open (524 LOC component with heavy deps)
- **Fix loading UX flash** — switching to Issues/PRs tabs no longer briefly shows "No issues"/"No pull requests" empty state before data loads. Root cause: `setError(null)` was resetting `isLoading: false` before the async fetch completed. Added `hasFetched` flag and conditional `setError` logic
- **Improve spinner icons** — refresh buttons show `RefreshCw` when idle, swap to spinning `Loader2` when loading. Suspense fallback overlays use `Loader2` spinner instead of text

## Test plan
- [x] Switch between Dashboard, Issues, and Pull Requests tabs — skeleton loaders should appear, no empty state flash
- [x] Click refresh button on Issues/PRs — should show spinning Loader2 while fetching, then RefreshCw when done
- [x] Open Settings modal — should show spinner overlay briefly on first load
- [x] Open GitHub Push Preview in validation panel — should show spinner overlay briefly on first load
- [x] Verify no regressions in validation flow and review flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)