### PR TITLE
feat: add husky pre-commit hook and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged


### PR DESCRIPTION
## Summary
- Add missing `.husky/pre-commit` file that triggers `npx lint-staged` on every commit, enabling automatic `eslint --fix` and `prettier --write` on staged files
- Add `.editorconfig` for consistent editor-level formatting defaults (charset, indentation, line endings)
- All husky/lint-staged dependencies and config were already in `package.json` — only the hook file was missing, causing pre-commit checks to silently skip

## Test plan
- [x] Run `git commit` with a staged `.ts` file containing a formatting issue — verify lint-staged runs and auto-fixes it
- [x] Run `git commit` with a staged `.ts` file containing an unfixable eslint error — verify the commit is blocked
- [x] Verify CI still passes (husky is already disabled in CI via `HUSKY: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)